### PR TITLE
TTE tte_get_text_size fixes

### DIFF
--- a/src/tte/tte_main.c
+++ b/src/tte/tte_main.c
@@ -726,7 +726,7 @@ POINT16 tte_get_text_size(const char *str)
 			if(ch>=0x80)
 				ch= utf8_decode_char(str-1, &str);
 
-			charW= tc->font->cellW;
+			charW= tte_get_glyph_width(tte_get_glyph_id(ch));
 			if(x+charW > tc->marginRight)
 			{
 				height += charH;		
@@ -735,7 +735,7 @@ POINT16 tte_get_text_size(const char *str)
 				x=0;			
 			}
 			else
-				x += tte_get_glyph_width(tte_get_glyph_id(ch));	
+				x += charW;
 		}
 	}
 

--- a/src/tte/tte_main.c
+++ b/src/tte/tte_main.c
@@ -712,12 +712,18 @@ POINT16 tte_get_text_size(const char *str)
 			break;			
 
 		// --- Special char ---
-		case '\\':
-			//# Use cmd-functino
+		case '#':
+			//# Use cmd-function
 			//# Take care of positioning commands.
 			if(str[0] == '{')
 				str= tte_cmd_skip(str);
 			break;
+
+		case '\\':
+			// Escaped command: skip '\\' if next glyph is '#'
+			if(str[0] == '#')
+				ch= *str++;
+			// FALLTHRU
 
 		// --- Normal char ---
 		default:


### PR DESCRIPTION
This PR fixes `tte_get_text_size` sometimes giving incorrect results, due to it using the maximum glyph width to determine whether a line wrap occurs. It now behaves consistently with `tte_write` and `tte_putc`, which use the actual width of the glyph they're trying to render.

In addition, `tte_get_text_size` now properly skips TTE command sequences (`"#{...}"`) and also interprets `\#` as `#` i.e. understands that commands can be escaped (though I haven't testing this escaping functionality).