### PR TITLE
TTE: add line spacing attribute

### DIFF
--- a/include/tonc_tte.h
+++ b/include/tonc_tte.h
@@ -316,6 +316,7 @@ typedef struct TTC
 	u16 marginBottom;
 	s16	savedX;
 	s16	savedY;
+	s16 lineSpacing;			//!< Extra line spacing
 	// Callbacks and table pointers
 	fnDrawg	drawgProc;			//!< Glyph render procedure.
 	fnErase	eraseProc;			//!< Text eraser procedure.
@@ -338,13 +339,13 @@ extern TTC *gp_tte_context;
 // --- Main Font data ---
 extern const TFont sys8Font;		//!< System font ' '-127. FWF  8x 8\@1.
 
-extern const TFont verdana9Font;	//!< Verdana 9 ' '-'ÿ'. VWF  8x12\@1.
-extern const TFont verdana9bFont;	//!< Verdana 9 bold ' '-'ÿ'. VWF  8x12\@1.
-extern const TFont verdana9iFont;	//!< Verdana 9 italic ' '-'ÿ'. VWF  8x12\@1.
+extern const TFont verdana9Font;	//!< Verdana 9 ' '-'ï¿½'. VWF  8x12\@1.
+extern const TFont verdana9bFont;	//!< Verdana 9 bold ' '-'ï¿½'. VWF  8x12\@1.
+extern const TFont verdana9iFont;	//!< Verdana 9 italic ' '-'ï¿½'. VWF  8x12\@1.
 
-extern const TFont verdana10Font;	//!< Verdana 10 ' '-'ÿ'. VWF 16x14\@1.
+extern const TFont verdana10Font;	//!< Verdana 10 ' '-'ï¿½'. VWF 16x14\@1.
 		
-extern const TFont verdana9_b4Font;	//!< Verdana 9 ' '-'ÿ'. VWF  8x12\@4.
+extern const TFont verdana9_b4Font;	//!< Verdana 9 ' '-'ï¿½'. VWF  8x12\@4.
 
 
 // --- Extra font data ---
@@ -425,6 +426,7 @@ INLINE u16 tte_get_ink(void);
 INLINE u16 tte_get_shadow(void);
 INLINE u16 tte_get_paper(void);
 INLINE u16 tte_get_special(void);
+INLINE s16 tte_get_line_spacing(void);
 
 INLINE TSurface *tte_get_surface(void);
 INLINE TFont *tte_get_font(void);
@@ -440,6 +442,7 @@ INLINE void tte_set_ink(u16 cattr);
 INLINE void tte_set_shadow(u16 cattr);
 INLINE void tte_set_paper(u16 cattr);
 INLINE void tte_set_special(u16 cattr);
+INLINE void tte_set_line_spacing(s16 spacing);
 
 INLINE void tte_set_surface(const TSurface *srf);
 INLINE void tte_set_font(const TFont *font);
@@ -704,6 +707,15 @@ INLINE u16 tte_get_paper(void)
 //! Get special color attribute.
 INLINE u16 tte_get_special(void)
 {	return tte_get_context()->cattr[TTE_SPECIAL];	}
+
+
+//! Get extra line spacing.
+INLINE s16 tte_get_line_spacing(void)
+{	return tte_get_context()->lineSpacing;	}
+
+//! Set extra line spacing.
+INLINE void tte_set_line_spacing(s16 spacing)
+{	tte_get_context()->lineSpacing= spacing;	}
 
 
 //! Set the character plotter

--- a/include/tonc_tte.h
+++ b/include/tonc_tte.h
@@ -339,13 +339,13 @@ extern TTC *gp_tte_context;
 // --- Main Font data ---
 extern const TFont sys8Font;		//!< System font ' '-127. FWF  8x 8\@1.
 
-extern const TFont verdana9Font;	//!< Verdana 9 ' '-'�'. VWF  8x12\@1.
-extern const TFont verdana9bFont;	//!< Verdana 9 bold ' '-'�'. VWF  8x12\@1.
-extern const TFont verdana9iFont;	//!< Verdana 9 italic ' '-'�'. VWF  8x12\@1.
+extern const TFont verdana9Font;	//!< Verdana 9 ' '-'ÿ'. VWF  8x12\@1.
+extern const TFont verdana9bFont;	//!< Verdana 9 bold ' '-'ÿ'. VWF  8x12\@1.
+extern const TFont verdana9iFont;	//!< Verdana 9 italic ' '-'ÿ'. VWF  8x12\@1.
 
-extern const TFont verdana10Font;	//!< Verdana 10 ' '-'�'. VWF 16x14\@1.
-		
-extern const TFont verdana9_b4Font;	//!< Verdana 9 ' '-'�'. VWF  8x12\@4.
+extern const TFont verdana10Font;	//!< Verdana 10 ' '-'ÿ'. VWF 16x14\@1.
+
+extern const TFont verdana9_b4Font;	//!< Verdana 9 ' '-'ÿ'. VWF  8x12\@4.
 
 
 // --- Extra font data ---

--- a/src/tte/tte_main.c
+++ b/src/tte/tte_main.c
@@ -556,7 +556,7 @@ int tte_putc(int ch)
 	
 	if(tc->cursorX+charW > tc->marginRight)
 	{
-		tc->cursorY += font->charH;
+		tc->cursorY += font->charH + tc->lineSpacing;
 		tc->cursorX  = tc->marginLeft;
 	}
 
@@ -594,7 +594,7 @@ int	tte_write(const char *text)
 				str++;
 			// FALLTHRU
 		case '\n':
-			tc->cursorY += tc->font->charH;
+			tc->cursorY += tc->font->charH + tc->lineSpacing;
 			tc->cursorX  = tc->marginLeft;
 			break;
 		// --- Tab ---
@@ -627,7 +627,7 @@ int	tte_write(const char *text)
 			int charW= font->widths ? font->widths[gid] : font->charW;
 			if(tc->cursorX+charW > tc->marginRight)
 			{
-				tc->cursorY += font->charH;
+				tc->cursorY += font->charH + tc->lineSpacing;
 				tc->cursorX  = tc->marginLeft;
 			}
 
@@ -705,7 +705,7 @@ POINT16 tte_get_text_size(const char *str)
 				str++;
 			// FALLTHRU
 		case '\n':
-			height += charH;
+			height += charH + tc->lineSpacing;
 			if(x > width)
 				width= x;
 			x= 0;
@@ -729,7 +729,7 @@ POINT16 tte_get_text_size(const char *str)
 			charW= tc->font->cellW;
 			if(x+charW > tc->marginRight)
 			{
-				height += charH;		
+				height += charH + tc->lineSpacing;
 				if(x>width)
 					width= x;
 				x=0;			


### PR DESCRIPTION
This PR adds a lineSpacing attribute to Tonc Text Engine, which specifies the amount of extra vertical pixels to be inserted between line breaks.

Advantages of this:
- when localising your game you can adjust the line spacing for languages which have taller glyphs, without needing to create a separate font for each language
- unlike modifying the `charH` property of the font, the line spacing isn't added until a linebreak occurs, therefore you don't waste pixels on the final line (so can cram text into a smaller vertical space without exceeding the bounds or wasting VRAM)